### PR TITLE
Use a specific version of the SecretHub CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN go build -o demo ./main.go
 FROM alpine
 COPY --from=build /build/demo /usr/bin/demo
 
-RUN apk add --repository https://alpine.secrethub.io/alpine/edge/main --allow-untrusted secrethub-cli
+RUN apk add --repository https://alpine.secrethub.io/alpine/edge/main --allow-untrusted secrethub-cli=0.34.0-r0
 ADD secrethub.env .
 
 EXPOSE 8080


### PR DESCRIPTION
By upgrading to v0.34.0 the demo-app image can be ran in AWS EKS
using a SecretHub service that uses AWS native identity.

By pinning the version in the image, we ensure fully reproducable
builds and can make changes like the current upgrade explicit.